### PR TITLE
specify python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.8-slim
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Latest `python:slim` as of early 2023 is 3.11, and dlib fails to build. Specifying 3.8 makes it work.